### PR TITLE
fix(ci): use correct Vault role in destroy_preview job

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -285,7 +285,7 @@ jobs:
         with:
           url: https://vault.yral.com
           method: jwt
-          role: yral-metadata-role
+          role: yral-video-storage-service-role
           jwtGithubAudience: "https://github.com/dolr-ai"
           secrets: |
             secret/data/COOLIFY_TOKEN value | COOLIFY_TOKEN ;


### PR DESCRIPTION
## Summary
- `destroy_preview` was authenticating to Vault with `yral-metadata-role`, which has a `repository` bound claim that excludes this repo
- `preview` (same workflow, same secrets) correctly uses `yral-video-storage-service-role`
- This caused a 400 on every PR close, leaving preview environments undeleted

## Test plan
- [ ] Merge this PR
- [ ] Open and close a test PR — confirm `destroy_preview` succeeds and Coolify app is deleted

closes https://github.com/dolr-ai/yral/issues/1998