### PR TITLE
fix(ci): fix destroy_preview Vault role and skip build on PR close

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   build_binary:
+    if: ${{ github.event.pull_request.state == 'open' }}
     uses: ./.github/workflows/build-binary.yml
     with:
       publish-artifact: true


### PR DESCRIPTION
## Summary
- `destroy_preview` was using `yral-metadata-role` in Vault, which has a `repository` bound claim that excludes this repo — causing 400 on every PR close and leaving preview environments undeleted
- `build_binary` had no `if` guard so it ran unnecessarily on `closed` events, wasting CI minutes on a binary that `destroy_preview` doesn't need

## Test plan
- [ ] Merge this PR
- [ ] Open a test PR, push a commit — confirm `build_binary` + `preview` + `e2e-tests` all run
- [ ] Close the test PR — confirm only `destroy_preview` runs and the Coolify app is deleted