### PR TITLE
fix(chain-audit): canonical key strips <principal>/ prefix — video_id

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -32,12 +32,13 @@ WHERE phash IS NOT NULL
 CREATE INDEX IF NOT EXISTS idx_phash_versioned_val
     ON video_index (phash_kind, phash_version, phash)
     WHERE phash IS NOT NULL;
--- Canonical video-key index (lowercased, dashes stripped) for the chain-audit
--- join, which normalizes video_uid <-> video_id to match dashed vs undashed
--- uuids. `lower`+`replace` are IMMUTABLE, so indexable. Lives here (not in the
--- media_index schema) because `video_index` is created by this schema.
+-- Canonical video-key index for the chain-audit join. video_index.video_id is
+-- the full path "<principal>/<uid>"; the chain sends the bare "<uid>", so the
+-- canonical key strips the "<principal>/" prefix, then dashes, then lowercases.
+-- IMMUTABLE exprs → indexable. Lives here (not in the media_index schema)
+-- because `video_index` is created by this schema.
 CREATE INDEX IF NOT EXISTS idx_video_index_video_id_norm
-    ON video_index (lower(replace(video_id, '-', '')));
+    ON video_index (lower(replace(regexp_replace(video_id, '^.*/', ''), '-', '')));
 -- Drop stale trigger from old single-table schema.
 DROP TRIGGER IF EXISTS video_index_updated_at ON video_index;
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -37,7 +37,10 @@ CREATE INDEX IF NOT EXISTS idx_phash_versioned_val
 -- canonical key strips the "<principal>/" prefix, then dashes, then lowercases.
 -- IMMUTABLE exprs → indexable. Lives here (not in the media_index schema)
 -- because `video_index` is created by this schema.
-CREATE INDEX IF NOT EXISTS idx_video_index_video_id_norm
+-- New name (see media_index schema note): drop the stale dash-only index, build
+-- fresh under a new name so CREATE-IF-NOT-EXISTS actually applies the new expr.
+DROP INDEX IF EXISTS idx_video_index_video_id_norm;
+CREATE INDEX IF NOT EXISTS idx_video_index_video_key
     ON video_index (lower(replace(regexp_replace(video_id, '^.*/', ''), '-', '')));
 -- Drop stale trigger from old single-table schema.
 DROP TRIGGER IF EXISTS video_index_updated_at ON video_index;

--- a/src/db.rs
+++ b/src/db.rs
@@ -33,12 +33,12 @@ CREATE INDEX IF NOT EXISTS idx_phash_versioned_val
     ON video_index (phash_kind, phash_version, phash)
     WHERE phash IS NOT NULL;
 -- Canonical video-key index for the chain-audit join. video_index.video_id is
--- the full path "<principal>/<uid>"; the chain sends the bare "<uid>", so the
--- canonical key strips the "<principal>/" prefix, then dashes, then lowercases.
--- IMMUTABLE exprs → indexable. Lives here (not in the media_index schema)
--- because `video_index` is created by this schema.
--- New name (see media_index schema note): drop the stale dash-only index, build
--- fresh under a new name so CREATE-IF-NOT-EXISTS actually applies the new expr.
+-- the full path principal-slash-uid; the chain sends the bare uid, so the
+-- canonical key strips the principal prefix (up to last slash), then dashes,
+-- then lowercases. IMMUTABLE exprs, so indexable. Lives here (not in the
+-- media_index schema) because video_index is created by this schema.
+-- New name: drop the stale dash-only index, build fresh under a new name so
+-- CREATE-IF-NOT-EXISTS actually applies the new expression.
 DROP INDEX IF EXISTS idx_video_index_video_id_norm;
 CREATE INDEX IF NOT EXISTS idx_video_index_video_key
     ON video_index (lower(replace(regexp_replace(video_id, '^.*/', ''), '-', '')));

--- a/src/media_index/chain_repo.rs
+++ b/src/media_index/chain_repo.rs
@@ -133,17 +133,17 @@ cat AS (
         h.video_id IS NOT NULL AS has_hash,
         vi.video_id IS NOT NULL AS in_index,
         EXISTS (SELECT 1 FROM media_job_failures f
-                WHERE lower(replace(f.video_id, '-', '')) = e.vk
+                WHERE lower(replace(regexp_replace(f.video_id, '^.*/', ''), '-', '')) = e.vk
                   AND f.job_kind = 'media_phash'
                   AND f.next_retry_at > now()) AS backing_off
     FROM expected e
-    LEFT JOIN all_servable_videos_on_yral m ON lower(replace(m.video_id, '-', '')) = e.vk
+    LEFT JOIN all_servable_videos_on_yral m ON lower(replace(regexp_replace(m.video_id, '^.*/', ''), '-', '')) = e.vk
     LEFT JOIN servable_video_hashes h
-        ON lower(replace(h.video_id, '-', '')) = e.vk
+        ON lower(replace(regexp_replace(h.video_id, '^.*/', ''), '-', '')) = e.vk
        AND h.hash_kind = '{hk}'
        AND h.hash_version = '{hv}'
        AND h.input_media_version = '{imv}'
-    LEFT JOIN video_index vi ON lower(replace(vi.video_id, '-', '')) = e.vk
+    LEFT JOIN video_index vi ON lower(replace(regexp_replace(vi.video_id, '^.*/', ''), '-', '')) = e.vk
 )
 SELECT
   (SELECT count(*) FROM cat) AS total_expected,
@@ -190,8 +190,8 @@ pub async fn join_key_match_rate(
         )
         SELECT count(*) AS total,
                count(*) FILTER (WHERE
-                   EXISTS (SELECT 1 FROM all_servable_videos_on_yral m WHERE lower(replace(m.video_id, '-', '')) = s.vk)
-                OR EXISTS (SELECT 1 FROM video_index vi WHERE lower(replace(vi.video_id, '-', '')) = s.vk)) AS matched
+                   EXISTS (SELECT 1 FROM all_servable_videos_on_yral m WHERE lower(replace(regexp_replace(m.video_id, '^.*/', ''), '-', '')) = s.vk)
+                OR EXISTS (SELECT 1 FROM video_index vi WHERE lower(replace(regexp_replace(vi.video_id, '^.*/', ''), '-', '')) = s.vk)) AS matched
         FROM s"#,
                 expected = EXPECTED_STATUSES
             ),
@@ -223,8 +223,8 @@ pub async fn category_d_sample(
         )
         SELECT e.video_uid, e.creator
         FROM expected e
-        LEFT JOIN all_servable_videos_on_yral m ON lower(replace(m.video_id, '-', '')) = e.vk
-        LEFT JOIN video_index vi ON lower(replace(vi.video_id, '-', '')) = e.vk
+        LEFT JOIN all_servable_videos_on_yral m ON lower(replace(regexp_replace(m.video_id, '^.*/', ''), '-', '')) = e.vk
+        LEFT JOIN video_index vi ON lower(replace(regexp_replace(vi.video_id, '^.*/', ''), '-', '')) = e.vk
         WHERE m.video_id IS NULL AND vi.video_id IS NULL
         ORDER BY e.video_uid
         LIMIT $1"#,
@@ -254,12 +254,12 @@ pub async fn worst_creators(
         non_clean AS (
             SELECT e.video_uid
             FROM expected e
-            LEFT JOIN all_servable_videos_on_yral m ON lower(replace(m.video_id, '-', '')) = e.vk
+            LEFT JOIN all_servable_videos_on_yral m ON lower(replace(regexp_replace(m.video_id, '^.*/', ''), '-', '')) = e.vk
             LEFT JOIN servable_video_hashes h
-                ON lower(replace(h.video_id, '-', '')) = e.vk
+                ON lower(replace(regexp_replace(h.video_id, '^.*/', ''), '-', '')) = e.vk
                AND h.hash_kind='{hk}' AND h.hash_version='{hv}'
                AND h.input_media_version='{imv}'
-            LEFT JOIN video_index vi ON lower(replace(vi.video_id, '-', '')) = e.vk
+            LEFT JOIN video_index vi ON lower(replace(regexp_replace(vi.video_id, '^.*/', ''), '-', '')) = e.vk
             WHERE NOT (m.video_id IS NOT NULL AND m.servable_status='servable' AND h.video_id IS NOT NULL)
         )
         SELECT p.creator_principal, count(DISTINCT p.video_uid) AS n
@@ -318,9 +318,9 @@ pub async fn category_b_video_ids(
         SELECT DISTINCT m.video_id
         FROM expected e
         JOIN all_servable_videos_on_yral m
-            ON lower(replace(m.video_id, '-', '')) = e.vk AND m.servable_status = 'servable'
+            ON lower(replace(regexp_replace(m.video_id, '^.*/', ''), '-', '')) = e.vk AND m.servable_status = 'servable'
         LEFT JOIN servable_video_hashes h
-            ON lower(replace(h.video_id, '-', '')) = e.vk
+            ON lower(replace(regexp_replace(h.video_id, '^.*/', ''), '-', '')) = e.vk
            AND h.hash_kind='{hk}' AND h.hash_version='{hv}'
            AND h.input_media_version='{imv}'
         WHERE h.video_id IS NULL
@@ -403,8 +403,8 @@ pub async fn join_key_diag(
                  FROM yral_posts WHERE NOT stale LIMIT $1
              )
              SELECT s.video_uid, s.status,
-                 EXISTS (SELECT 1 FROM all_servable_videos_on_yral m WHERE lower(replace(m.video_id, '-', '')) = s.vk) AS in_master,
-                 EXISTS (SELECT 1 FROM video_index vi WHERE lower(replace(vi.video_id, '-', '')) = s.vk) AS in_index
+                 EXISTS (SELECT 1 FROM all_servable_videos_on_yral m WHERE lower(replace(regexp_replace(m.video_id, '^.*/', ''), '-', '')) = s.vk) AS in_master,
+                 EXISTS (SELECT 1 FROM video_index vi WHERE lower(replace(regexp_replace(vi.video_id, '^.*/', ''), '-', '')) = s.vk) AS in_index
              FROM s",
             &[&sample],
         )
@@ -658,6 +658,33 @@ mod tests {
         // remediation emits the RAW dashed master id (not the chain uid)
         let b_ids = category_b_video_ids(&c, 100).await.unwrap();
         assert_eq!(b_ids, vec![dashed_b.to_string()]);
+    }
+
+    #[tokio::test]
+    async fn principal_prefixed_master_matches_bare_chain_uid() {
+        // Prod reality: master/video_index store video_id = "<principal>/<uid>",
+        // but the chain sends the bare "<uid>". The canonical key strips the
+        // "<principal>/" prefix so they match.
+        let (_pg, c) = setup().await;
+        let run = uuid::Uuid::new_v4();
+        let uid = "f742370ca7730811060ee907b9111777";
+        let master_id = format!("kyxqt-t4e7d-stmey/{uid}"); // <principal>/<uid>
+        seed_master(&c, &master_id, "servable").await; // B: in master, no hash
+        upsert_chain_post(&c, &post("pp", uid, "cc", "Uploaded"), run)
+            .await
+            .unwrap();
+
+        let rep = chain_audit(&c).await.unwrap();
+        assert_eq!(rep.category_b, 1); // matched via suffix — NOT a phantom D
+        assert_eq!(rep.category_d, 0);
+
+        let diag = join_key_diag(&c, 500).await.unwrap();
+        assert_eq!(diag.in_master, 1);
+
+        // remediation emits the FULL master video_id ("<principal>/<uid>") — the
+        // value media-phash actually keys on, NOT the bare chain uid.
+        let b = category_b_video_ids(&c, 100).await.unwrap();
+        assert_eq!(b, vec![master_id]);
     }
 
     #[tokio::test]

--- a/src/media_index/schema.rs
+++ b/src/media_index/schema.rs
@@ -205,9 +205,15 @@ CREATE TABLE IF NOT EXISTS yral_users (
 -- chain-audit join compares video_uid <-> video_id on this form. Without these
 -- indexes the joins seq-scan the full master table and time out on prod.
 -- `lower`/`replace`/`regexp_replace` are IMMUTABLE, so indexable.
-CREATE INDEX IF NOT EXISTS idx_master_video_id_norm
+-- NEW index names (…_video_key). The prior …_video_id_norm indexes used a
+-- dash-only expression; CREATE IF NOT EXISTS matches by NAME, so reusing the
+-- name would keep the stale expression. Drop the old ones (one-time; no-op
+-- afterwards) and build fresh under new names.
+DROP INDEX IF EXISTS idx_master_video_id_norm;
+CREATE INDEX IF NOT EXISTS idx_master_video_key
     ON all_servable_videos_on_yral (lower(replace(regexp_replace(video_id, '^.*/', ''), '-', '')));
-CREATE INDEX IF NOT EXISTS idx_hashes_video_id_norm
+DROP INDEX IF EXISTS idx_hashes_video_id_norm;
+CREATE INDEX IF NOT EXISTS idx_hashes_video_key
     ON servable_video_hashes (lower(replace(regexp_replace(video_id, '^.*/', ''), '-', '')));
 CREATE INDEX IF NOT EXISTS idx_yral_posts_video_uid_norm
     ON yral_posts (lower(replace(video_uid, '-', '')));

--- a/src/media_index/schema.rs
+++ b/src/media_index/schema.rs
@@ -198,15 +198,17 @@ CREATE TABLE IF NOT EXISTS yral_users (
     last_seen TIMESTAMPTZ
 );
 
--- Functional indexes on the CANONICAL video key (lowercased, dashes stripped).
--- The chain-audit join compares video_uid <-> video_id on this normalized form
--- because storj keys (hence video_id) and chain video_uid appear both dashed and
--- undashed. Without these, the audit/diagnostic joins seq-scan the full master
--- table and time out on prod. `lower`+`replace` are IMMUTABLE, so indexable.
+-- Functional indexes on the CANONICAL video key. Our video_id is the full
+-- storage path "<principal>/<uid>" (both dashed and undashed uuid forms exist),
+-- but the chain sends the bare "<uid>". Canonical = strip everything up to the
+-- last '/' (drop the principal prefix), then strip dashes + lowercase. The
+-- chain-audit join compares video_uid <-> video_id on this form. Without these
+-- indexes the joins seq-scan the full master table and time out on prod.
+-- `lower`/`replace`/`regexp_replace` are IMMUTABLE, so indexable.
 CREATE INDEX IF NOT EXISTS idx_master_video_id_norm
-    ON all_servable_videos_on_yral (lower(replace(video_id, '-', '')));
+    ON all_servable_videos_on_yral (lower(replace(regexp_replace(video_id, '^.*/', ''), '-', '')));
 CREATE INDEX IF NOT EXISTS idx_hashes_video_id_norm
-    ON servable_video_hashes (lower(replace(video_id, '-', '')));
+    ON servable_video_hashes (lower(replace(regexp_replace(video_id, '^.*/', ''), '-', '')));
 CREATE INDEX IF NOT EXISTS idx_yral_posts_video_uid_norm
     ON yral_posts (lower(replace(video_uid, '-', '')));
 "#;


### PR DESCRIPTION
… is <principal>/<uid> but chain sends bare <uid> (verified on prod: 8/12 head-slice now match, was 0)