### PR TITLE
fix: wait for Patroni REST readiness before db-backup primary gate

### DIFF
--- a/deploy/scripts/deploy/backup-loop.sh
+++ b/deploy/scripts/deploy/backup-loop.sh
@@ -46,12 +46,35 @@ export RCLONE_CONFIG_HZ_REGION="$REGION"
 export RCLONE_CONFIG_HZ_ACL=private
 REMOTE="hz:${BUCKET}/${PREFIX}"
 
+# Patroni REST answers at all (any HTTP status) => it finished starting. Lets us tell
+# "not ready yet" (TCP refused at boot) apart from "ready but a replica" (HTTP 503), so
+# a startup race doesn't cost a full poll interval before the first backup.
+patroni_rest_up() {
+  code="$(curl -s -o /dev/null --max-time 10 -w '%{http_code}' \
+    "http://${PATRONI_HOST}:${PATRONI_PORT}/patroni" 2>/dev/null || echo 000)"
+  [ "$code" != "000" ]
+}
+
+wait_for_patroni() {
+  i=0
+  while [ "$i" -lt "${PATRONI_WAIT_TRIES:-30}" ]; do
+    patroni_rest_up && return 0
+    i=$((i + 1))
+    sleep "${PATRONI_WAIT_SECS:-5}"
+  done
+  return 1
+}
+
 is_primary() {
   curl -fsS -o /dev/null --max-time 10 \
     "http://${PATRONI_HOST}:${PATRONI_PORT}/primary"
 }
 
 run_cycle() {
+  if ! wait_for_patroni; then
+    log "patroni REST unreachable after wait — skipping this cycle"
+    return 0
+  fi
   if ! is_primary; then
     log "local node is not the primary — skipping"
     return 0


### PR DESCRIPTION
The db-backup loop gated on GET patroni:8008/primary and treated a TCP-refused (Patroni REST not up yet) the same as a genuine replica (HTTP 503): both skipped. On a fresh boot db-backup often starts before Patroni's REST is listening, so the primary node skipped and, with poll=3600s, would not retry for an hour — no backup for up to an hour after every (re)deploy.

Add wait_for_patroni(): poll /patroni until it returns any HTTP status (REST up) before checking the primary role. Distinguishes 'not ready' from 'replica', so the primary backs up on the first cycle. Replicas still return immediately (503) with no added wait.